### PR TITLE
チロルからスピカに装備を渡すとDuplicateEquipsを吐いてしまうバグを修正

### DIFF
--- a/config/constants.yml.erb
+++ b/config/constants.yml.erb
@@ -1,4 +1,4 @@
-version: 0.5.1
+version: 0.5.2
 
 default_event_interval_seconds: <%= Rails.env.production? ? 30 : 30 %>
 minimum_event_interval_seconds: 4

--- a/spec/models/user/character_spec.rb
+++ b/spec/models/user/character_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe User::Character, type: :model do
     subject { character.equip_item_ids }
     context "when no equip" do
       before do
-        allow(character).to receive_message_chain(:equips, :map).and_return([nil, nil, nil, nil])
+        allow(character).to receive_message_chain(:equips, :reload, :map).and_return([nil, nil, nil, nil])
       end
       it "returns list of nil" do
         expect(subject).to eq([nil, nil, nil, nil])
@@ -46,7 +46,7 @@ RSpec.describe User::Character, type: :model do
       let(:item){create(:item)}
       let(:user_item){ create(:user_item, item_id: item.id, user: user)}
       before do
-        allow(character).to receive_message_chain(:equips, :map).and_return([user_item, nil, nil, nil])
+        allow(character).to receive_message_chain(:equips, :reload, :map).and_return([user_item, nil, nil, nil])
       end
       it "returns list of item_ids" do
         expect(subject).to eq([item.id, nil, nil, nil])


### PR DESCRIPTION
fix https://twitter.com/Guyst_Marnonce/status/1342449734032584705

> スピカのATKを53万以上にしてもある種の到達点の実績が達成扱いになりませんでした。試しにリロードをすると装備変更前の状態に戻ってしまうのが原因？リロード後、地味にATKとDEFの数値が次回イベント更新まで数値が正常に表示されないことも動画を撮ることによる副産物で発見出来ました

チロルの手持ち装備が古いままなのが良くなかった... とりあえずの対策としてreloadするようにします。